### PR TITLE
docs: add syntax highlighting and fix several problems from markdownlint

### DIFF
--- a/Java/Typing.md
+++ b/Java/Typing.md
@@ -12,7 +12,7 @@ Most of the time, the phrase **readability over reusability** comes on the way o
 
 This rules applies for **Maven** based structures. I have been using Maven more often than **Gradle** because its simplicity for small scale projects.
 
-```
+```txt
 src
 ├── main
 │   ├── database               Database sources
@@ -20,20 +20,20 @@ src
 │   ├── resources              Application/Library resources
 │   ├── filters                Resource filter files
 │   └── webapp                 Web application sources
-│   
+│
 └── test
-	├── java                   Test sources
-	├── resources              Test resources
-	└── filters                Test resource filter files
+   ├── java                   Test sources
+   ├── resources              Test resources
+   └── filters                Test resource filter files
 ```
 
 ## Naming conventions, whitespaces, indentations, restrictions
 
 | Nr  | Naming Rule            | Rule                                    | Example            |
-|:---:| ---------------------- | --------------------------------------- | ------------------ |
+| :-: | ---------------------- | --------------------------------------- | ------------------ |
 |  1  | Classes and Interfaces | Should be nouns, capitalized            | `Canal`            |
 |  2  | Interfaces             | Adjectives ending with "-able"          | `Traversable`      |
-|  3  | Variables              | `camelCase` style, short but meaningful | `closed`           | 
+|  3  | Variables              | `camelCase` style, short but meaningful | `closed`           |
 |  4  | Constant Variables     | Capitalized, separated with underscores | `DEFAULT_WIDTH`    |
 |  5  | Packages               | lowercase letters                       | `sample.naming`    |
 |  6  | Variable Assignments   | Whitespaces around `=`                  | `this.id = id`     |
@@ -41,36 +41,36 @@ src
 
 Other than that, **indentations** are also important to separate scopes of codes. In most cases, 4 characters indent to tab out between scopes. I rarely use 2 or 8 characters indentations.
 
-```
-package sample.naming;  
-  
-interface Traversable {  
-   void traverse();  
-}  
-  
-public class Canal implements Traversable {  
-  
-   public static final int DEFAULT_DISTANCE = 40;  
-   private String id;  
-   protected int distance;  
-   private boolean closed = false;  
-  
-   public Canal(String id) {  
-      // Calls the other constructor  
-      this(id, DEFAULT_DISTANCE);  
-   }  
-  
-   public Canal(String id, int distance) {  
-      this.id = id;  
-      this.distance = distance;  
-   }  
-  
-   public void traverse() {  
-      System.out.println("Traversing: " + id + ", distance: " + distance);  
-   }  
-  
-   public String getId() {  
-      return id;  
+```java
+package sample.naming;
+
+interface Traversable {
+   void traverse();
+}
+
+public class Canal implements Traversable {
+
+   public static final int DEFAULT_DISTANCE = 40;
+   private String id;
+   protected int distance;
+   private boolean closed = false;
+
+   public Canal(String id) {
+      // Calls the other constructor
+      this(id, DEFAULT_DISTANCE);
+   }
+
+   public Canal(String id, int distance) {
+      this.id = id;
+      this.distance = distance;
+   }
+
+   public void traverse() {
+      System.out.println("Traversing: " + id + ", distance: " + distance);
+   }
+
+   public String getId() {
+      return id;
    }
 }
 ```
@@ -79,77 +79,77 @@ public class Canal implements Traversable {
 
 A method should be short, understandable, and meaningful. Parameters should also be named according to the context. Some examples:
 
-```
+```java
 // Boolean getter methods may start with "has" or "is" following its context
-public boolean isClosed() {  
-   return closed;  
+public boolean isClosed() {
+   return closed;
 }
 ```
 
-```
+```java
 // Boolean methods may start with "has" or "is" following its context
-public boolean hasGate() {  
-   return gateId != null;  
+public boolean hasGate() {
+   return gateId != null;
 }
 ```
 
-```
+```java
 // This boolean method uses "can" because the context is able or not able to.
-public static boolean canConnectToDatabase() {  
-   try {  
-      getConnection();  
-      return true;  
-   } catch (SQLException e) {  
-      return false;  
-   }  
+public static boolean canConnectToDatabase() {
+   try {
+      getConnection();
+      return true;
+   } catch (SQLException e) {
+      return false;
+   }
 }
 ```
 
-```
+```java
 // Varargs may be used for repeating values (can be multiple single values)
-public int addInts(int... values) {  
-   int sum = 0;  
-   for (int value : values) {  
-      sum += value;  
-   }  
-   return sum;  
+public int addInts(int... values) {
+   int sum = 0;
+   for (int value : values) {
+      sum += value;
+   }
+   return sum;
 }
 ```
 
 ### Method parameter restriction
 
-Parameters are necessary when working with methods. However, care should be taken to avoid using too many parameters in one method. Too many parameters may indicate that your method is addressing more than one concern and violates the single responsibility principle. 
+Parameters are necessary when working with methods. However, care should be taken to avoid using too many parameters in one method. Too many parameters may indicate that your method is addressing more than one concern and violates the single responsibility principle.
 
 Too many method parameters make your code less readable since keeping track of their types and meanings is difficult. To write clean Java code, you should: limit the number of method parameters and use objects or data structures instead of individual parameters or group-related parameters into objects.
 
 Here is an example of a Java method with too many method parameters:
 
-```
-public void processOrder(String customerName, String shippingAddress, String billingAddress, String productName,   
-                   int quantity, double price, boolean isExpressShipping) {  
-   // Method implementation  
+```java
+public void processOrder(String customerName, String shippingAddress, String billingAddress, String productName,
+                   int quantity, double price, boolean isExpressShipping) {
+   // Method implementation
 }
 ```
 
 Refactoring the code by grouping it into one single class improves readability:
 
-```
+```java
 public class Order {
-	private String customerName;
-	private String shippingAddress;
-	private String billingAddress;
-	private String productName;
-	private int quantity;
-	private double price;
-	private boolean isExpressShipping;
-	
-	// Constructors, getters, and setters
-	
-	// Other methods related to an order
+   private String customerName;
+   private String shippingAddress;
+   private String billingAddress;
+   private String productName;
+   private int quantity;
+   private double price;
+   private boolean isExpressShipping;
+
+   // Constructors, getters, and setters
+
+   // Other methods related to an order
 }
 
 public void processOrder(Order order) {
-	// Method implementation
+   // Method implementation
 }
 ```
 
@@ -158,6 +158,7 @@ source: [digma.ai](https://digma.ai/blog/clean-code-java/)
 ### Code width restriction
 
 The code must be inside the **Right Margin** or the **Visual Guides** line. This line is a visual guide that helps you keep your code within a specified width or column limit. It's a common practice to limit the line length in code to improve readability and make it easier to view side-by-side in various environments. If the width is too large, it will be hard to read the rest of the code in a side-by-side environments. Continue the statement in the next line.
+
 ## Documentation
 
 ### Javadoc
@@ -168,20 +169,20 @@ Java provides simple built-in documentation feature called Javadoc and comments.
 | ---------------------------- | ------------------------------------------ |
 | `{@link HashMap}`            | References the class `HashMap`             |
 | `{@link HashMap#values}`     | Access the `values` attribute of the class |
-| `{@link HashMap#toString()}` | Calls the method `toString` of the class   | 
+| `{@link HashMap#toString()}` | Calls the method `toString` of the class   |
 
 Example:
 
-```
-/**  
- * Mendapatkan data {@link Peminjam} dari hasil pertama {@link ResultSet} yang diberikan.  
- * 
- * @param rs {@link ResultSet} yang akan diambil datanya.  
- * @return {@link Peminjam} jika ada, {@code null} jika tidak ada.  
+```java
+/**
+ * Mendapatkan data {@link Peminjam} dari hasil pertama {@link ResultSet} yang diberikan.
+ *
+ * @param rs {@link ResultSet} yang akan diambil datanya.
+ * @return {@link Peminjam} jika ada, {@code null} jika tidak ada.
  * @throws {@link SQLException} exception yang kemungkinan dinaikan.
  * */
 private static Peminjam getPeminjam(ResultSet rs) throws SQLException {
-	// ...
+   // ...
 }
 ```
 
@@ -189,26 +190,25 @@ private static Peminjam getPeminjam(ResultSet rs) throws SQLException {
 
 A comment briefly explains a snippet of code or set of instructions. It is used inside method scopes. Every line does not always need its own comment if unnecessary/obvious.
 
-```
-public static void printTest() {  
-   HashMap<String, Peminjam> dataPeminjam = readAllDataPeminjam();  
-   // Converts the map values into a list of Peminjam  
-   var arr = List.copyOf(dataPeminjam.values());  
-  
-   // Prints all elements of Peminjam in arr  
-   for (Peminjam p : arr) {  
-      System.out.println(p);  
-   }  
+```java
+public static void printTest() {
+   HashMap<String, Peminjam> dataPeminjam = readAllDataPeminjam();
+   // Converts the map values into a list of Peminjam
+   var arr = List.copyOf(dataPeminjam.values());
+
+   // Prints all elements of Peminjam in arr
+   for (Peminjam p : arr) {
+      System.out.println(p);
+   }
 }
 ```
 
-```
+```java
 public static void main(String[] args) {
-	/* 
-	 * This is a multi-line comment. 
-	 * It can span several lines. 
-	 */
-	System.out.println("Hello, World!"); 
+   /*
+    * This is a multi-line comment.
+    * It can span several lines.
+    */
+   System.out.println("Hello, World!");
 }
 ```
-


### PR DESCRIPTION
fix: 
- hard tabs ([MD010](https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md010.md))
- fenced code ([MD040](https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md040.md)) 
- trailing space ([MD009](https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md009.md)) 
- no blank line before and after heading ([MD022](https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md022.md)) 
- multiple consecutive blank lines ([MD012](https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md012.md))